### PR TITLE
Added new test case to confirm pipeline failures consuming large quantities of pipelined queries.

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1,9 +1,13 @@
 package golangNeo4jBoltDriver
 
 import (
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
+	"time"
+
+	blog "github.com/johnnadratowski/golang-neo4j-bolt-driver/log"
 )
 
 func TestBoltConn_Close(t *testing.T) {
@@ -180,4 +184,63 @@ func TestBoltConn_IgnoredPipeline(t *testing.T) {
 	if data[0][0].(int64) != 1 {
 		t.Fatalf("Expected different data from output: %#v", data)
 	}
+}
+
+func TestBoltConn_ExecPipeline(t *testing.T) {
+	blog.SetLevel("")
+	driver := NewDriver()
+
+	// Records session for testing
+	driver.(*boltDriver).recorder = newRecorder("TestBoltConn_IgnoredPipeline", neo4jConnStr)
+
+	conn, _ := driver.OpenNeo(neo4jConnStr)
+	d, _ := time.ParseDuration("5s")
+	conn.SetTimeout(d)
+	defer conn.Close()
+	start := time.Now()
+
+	query := "MERGE (c:Contact {id: {id}}) SET c.www = {www}, c.full_name = {full_name} " +
+		"WITH c " +
+		"OPTIONAL MATCH (m)-[existing:MANAGER]->(c) " +
+		"DELETE m, existing " +
+		"MERGE (c)<-[:MANAGER]-(:Manager { manager: {a} }) " +
+		"MERGE (c)<-[:MANAGER]-(:Manager { manager: {b} }) " +
+		"MERGE (c)<-[:MANAGER]-(:Manager { manager: {c} })"
+
+	var queries []string
+	var queryParams []map[string]interface{}
+
+	loopLimit := 8000
+	i := 0
+	for {
+		queryParam := make(map[string]interface{})
+		queryParam["id"] = "nothing unique here"
+		queryParam["www"] = "http://www.kylehq.com"
+		queryParam["full_name"] = "Kyle Clarke name drop yo!"
+		queryParam["a"] = "foo"
+		queryParam["b"] = "bar"
+		queryParam["c"] = "baz"
+		queryParams = append(queryParams, queryParam)
+		queries = append(queries, query)
+
+		i++
+		if i > loopLimit {
+			break
+		}
+	}
+
+	pipeline, err := conn.PreparePipeline(queries...)
+	if err != nil {
+		t.Fatalf("Got an error on prepare pipeline query: %#v", err)
+	}
+
+	_, err = pipeline.ExecPipeline(queryParams...)
+	if err != nil {
+		t.Fatalf("Got error on Exec pipeline: %#v", err)
+	}
+
+	fmt.Println(fmt.Sprintf("Pipeline took %f seconds to complete for %d iterations. Is this acceptable?", time.Since(start).Seconds(), loopLimit))
+
+	// Clean up
+	pipeline.Close()
 }


### PR DESCRIPTION
When using the https://github.com/johnnadratowski/golang-neo4j-bolt-driver library on my personal project https://gitlab.com/kylehqcom/norgie, I noted that failures would occur when **"pipelining"** 550+ queries through the driver. After looking into the code, I found that the actual pipelining runs perfectly well. The problem arises when the response is **"consumed"**.

It looks as though the problem lies with the entire response being read at once, instead of per query or chunked. As per https://gitlab.com/kylehqcom/golang-neo4j-bolt-driver/blob/master/encoding/decoder.go#L41

I've created a test case to confirm consistent failures by creating a large number of queries to pipeline, 8000 in my case. This is hardly scientific but at 8000 queries, my MBAir returns inconsistent results as follows.

```
02:15:25 {pipeline-test} golang-neo4j-bolt-driver$ NEO4J_BOLT=bolt://neo4j:password@localhost:7687 go test -v
=== RUN   TestBoltConn_ExecPipeline
--- FAIL: TestBoltConn_ExecPipeline (14.24s)
    conn_test.go:242: Got error on Exec pipeline: &errors.Error{msg:"An error occurred getting result of exec discard command: <nil>", wrapped:(*errors.Error)(0xc820ae6200), stack:[]uint8(nil), level:0}

02:15:54 {pipeline-test} golang-neo4j-bolt-driver$ NEO4J_BOLT=bolt://neo4j:password@localhost:7687 go test -v
=== RUN   TestBoltConn_ExecPipeline
Pipeline took 13.852108 seconds to complete for 8000 iterations. Is this acceptable?
--- PASS: TestBoltConn_ExecPipeline (13.86s)
FAIL    gitlab.com/kylehqcom/golang-neo4j-bolt-driver   18.991s

02:16:16 {pipeline-test} golang-neo4j-bolt-driver$ NEO4J_BOLT=bolt://neo4j:password@localhost:7687 go test -v
=== RUN   TestBoltConn_ExecPipeline
--- FAIL: TestBoltConn_ExecPipeline (10.49s)
    conn_test.go:242: Got error on Exec pipeline: &errors.Error{msg:"An error occurred getting result of exec discard command: <nil>", wrapped:(*errors.Error)(0xc8208649c0), stack:[]uint8(nil), level:0}

02:16:34 {pipeline-test} golang-neo4j-bolt-driver$ NEO4J_BOLT=bolt://neo4j:password@localhost:7687 go test -v
=== RUN   TestBoltConn_ExecPipeline
Pipeline took 26.267384 seconds to complete for 8000 iterations. Is this acceptable?
--- PASS: TestBoltConn_ExecPipeline (26.27s)
```

However, this can be made consistent by altering the **Timeout** value on the connection. It defaults to 10secs but I assigned 5secs https://gitlab.com/kylehqcom/golang-neo4j-bolt-driver/blob/pipeline-test/conn_test.go#L198

```
Setting a 5 second connection timeout

02:17:07 {pipeline-test} golang-neo4j-bolt-driver$ NEO4J_BOLT=bolt://neo4j:password@localhost:7687 go test -v
=== RUN   TestBoltConn_ExecPipeline
--- FAIL: TestBoltConn_ExecPipeline (10.54s)
    conn_test.go:242: Got error on Exec pipeline: &errors.Error{msg:"An error occurred getting result of exec discard command: <nil>", wrapped:(*errors.Error)(0xc820eed200), stack:[]uint8(nil), level:0}

02:19:03 {pipeline-test} golang-neo4j-bolt-driver$ NEO4J_BOLT=bolt://neo4j:password@localhost:7687 go test -v
=== RUN   TestBoltConn_ExecPipeline
--- FAIL: TestBoltConn_ExecPipeline (10.43s)
    conn_test.go:242: Got error on Exec pipeline: &errors.Error{msg:"An error occurred getting result of exec discard command: <nil>", wrapped:(*errors.Error)(0xc820763e40), stack:[]uint8(nil), level:0}

02:19:19 {pipeline-test} golang-neo4j-bolt-driver$ NEO4J_BOLT=bolt://neo4j:password@localhost:7687 go test -v
=== RUN   TestBoltConn_ExecPipeline
--- FAIL: TestBoltConn_ExecPipeline (11.25s)
    conn_test.go:242: Got error on Exec pipeline: &errors.Error{msg:"An error occurred getting result of exec discard command: <nil>", wrapped:(*errors.Error)(0xc8211b7bc0), stack:[]uint8(nil), level:0}
```
#### Note:

I am running my neo4j instance as a Docker container via my mac so assume that my initial 550 failures are a result of bad tuning straight out of the box. Regardless, we should either impose a limit to the pipeline but better still consume the decoded response with failures.

I have also discovered that full number of records continue to be added in the background to the Neo4j store even after the failure occurs?!?!
